### PR TITLE
Feature/48/add a message outbox

### DIFF
--- a/src/RentService/Controllers/RentsController.cs
+++ b/src/RentService/Controllers/RentsController.cs
@@ -71,13 +71,13 @@ public class RentsController : ControllerBase
         // Save rent to be created to memory
         _context.Rents.Add(rent);
 
-        // Save changes from memory to the database
-        var result = await _context.SaveChangesAsync();
-
         // Map the new created rent to RentDto
         // and publish it to the Event Bus
         var newRent = _mapper.Map<RentDto>(rent);
         await _publishEndpoint.Publish(_mapper.Map<RentCreated>(newRent));
+
+        // Save changes from memory to the database
+        var result = await _context.SaveChangesAsync();
 
         // If no changes were applied, the request has failed
         if (result == 0) return BadRequest("Could not save changes to the DB");

--- a/src/RentService/Data/Migrations/20241006194752_Outbox.Designer.cs
+++ b/src/RentService/Data/Migrations/20241006194752_Outbox.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RentService.Data;
@@ -11,9 +12,11 @@ using RentService.Data;
 namespace RentService.Data.Migrations
 {
     [DbContext(typeof(RentDbContext))]
-    partial class RentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241006194752_Outbox")]
+    partial class Outbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/RentService/Data/Migrations/20241006194752_Outbox.cs
+++ b/src/RentService/Data/Migrations/20241006194752_Outbox.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace RentService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Outbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InboxState",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ConsumerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true),
+                    Received = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ReceiveCount = table.Column<int>(type: "integer", nullable: false),
+                    ExpirationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Consumed = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Delivered = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InboxState", x => x.Id);
+                    table.UniqueConstraint("AK_InboxState_MessageId_ConsumerId", x => new { x.MessageId, x.ConsumerId });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OutboxMessage",
+                columns: table => new
+                {
+                    SequenceNumber = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    EnqueueTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    SentTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Headers = table.Column<string>(type: "text", nullable: true),
+                    Properties = table.Column<string>(type: "text", nullable: true),
+                    InboxMessageId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InboxConsumerId = table.Column<Guid>(type: "uuid", nullable: true),
+                    OutboxId = table.Column<Guid>(type: "uuid", nullable: true),
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    MessageType = table.Column<string>(type: "text", nullable: false),
+                    Body = table.Column<string>(type: "text", nullable: false),
+                    ConversationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CorrelationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InitiatorId = table.Column<Guid>(type: "uuid", nullable: true),
+                    RequestId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SourceAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    DestinationAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ResponseAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    FaultAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ExpirationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxMessage", x => x.SequenceNumber);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OutboxState",
+                columns: table => new
+                {
+                    OutboxId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true),
+                    Created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Delivered = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxState", x => x.OutboxId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxState_Delivered",
+                table: "InboxState",
+                column: "Delivered");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_EnqueueTime",
+                table: "OutboxMessage",
+                column: "EnqueueTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_ExpirationTime",
+                table: "OutboxMessage",
+                column: "ExpirationTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_InboxMessageId_InboxConsumerId_SequenceNumber",
+                table: "OutboxMessage",
+                columns: new[] { "InboxMessageId", "InboxConsumerId", "SequenceNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_OutboxId_SequenceNumber",
+                table: "OutboxMessage",
+                columns: new[] { "OutboxId", "SequenceNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxState_Created",
+                table: "OutboxState",
+                column: "Created");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "InboxState");
+
+            migrationBuilder.DropTable(
+                name: "OutboxMessage");
+
+            migrationBuilder.DropTable(
+                name: "OutboxState");
+        }
+    }
+}

--- a/src/RentService/Data/RentDbContext.cs
+++ b/src/RentService/Data/RentDbContext.cs
@@ -1,4 +1,5 @@
 using System;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using RentService.Entities;
 
@@ -11,4 +12,18 @@ public class RentDbContext : DbContext
     }
 
     public DbSet<Rent> Rents { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // Add the MassTransit inbox state to the database
+        modelBuilder.AddInboxStateEntity();
+
+        // Add the MassTransit outbox message to the database
+        modelBuilder.AddOutboxMessageEntity();
+
+        // Add the MassTransit outbox state to the database
+        modelBuilder.AddOutboxStateEntity();
+    }
 }

--- a/src/RentService/Program.cs
+++ b/src/RentService/Program.cs
@@ -13,10 +13,29 @@ builder.Services.AddDbContext<RentDbContext>(opt =>
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 builder.Services.AddMassTransit(x =>
 {
+    /*************  ✨ Codeium Command 🌟  *************/
+    // Set up the Entity Framework Outbox which is used to store messages in the database
+    // that are yet to be sent. This is useful if the application is shut down before all
+    // messages can be sent.
+    x.AddEntityFrameworkOutbox<RentDbContext>(o =>
+    {
+        // Delay each message in the outbox by 10 seconds before sending it
+        o.QueryDelay = TimeSpan.FromSeconds(10);
+
+        // Use Postgres as the database provider
+        o.UsePostgres();
+
+        // Use the outbox as the bus
+        o.UseBusOutbox();
+    });
+
+    // Set up the RabbitMQ message bus
     x.UsingRabbitMq((context, cfg) =>
     {
+        // Configure the endpoints for the RabbitMQ message bus
         cfg.ConfigureEndpoints(context);
     });
+    /******  17467043-c828-474d-9ca2-b665bf283724  *******/
 });
 
 var app = builder.Build();

--- a/src/RentService/Program.cs
+++ b/src/RentService/Program.cs
@@ -13,7 +13,6 @@ builder.Services.AddDbContext<RentDbContext>(opt =>
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 builder.Services.AddMassTransit(x =>
 {
-    /*************  ✨ Codeium Command 🌟  *************/
     // Set up the Entity Framework Outbox which is used to store messages in the database
     // that are yet to be sent. This is useful if the application is shut down before all
     // messages can be sent.
@@ -35,7 +34,6 @@ builder.Services.AddMassTransit(x =>
         // Configure the endpoints for the RabbitMQ message bus
         cfg.ConfigureEndpoints(context);
     });
-    /******  17467043-c828-474d-9ca2-b665bf283724  *******/
 });
 
 var app = builder.Build();

--- a/src/RentService/RentService.csproj
+++ b/src/RentService/RentService.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Description

- Added **Mass Transit Entity Framework Core** service to the _Rent_ Service
- Added _Inbox State_, _Outbox Message_ and _Outbox State_ entities on model creation of _Rent_
- Reordered _Rent_ creation logic so that created rent is _only saved_ after successful publishing of the creation, otherwise it waits in the message outbox to reach the event bus and _retries_ every **10** seconds.

## Git Issue Number

[48](https://github.com/Muhtasim-Fuad-Showmik/LeaseLifestyles/issues/48)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
<!-- - [ ] This change requires a documentation update -->

# How Has This Been Tested?

Tested by using a _POST_ request for creation of Rent with various services down and up to check for multiple scenarios

- [x] Manual Test
  <!-- - [ ] Unit Test -->
  <!-- - [ ] Integration Test -->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
  <!-- - [ ] I have made corresponding changes to the documentation -->
  <!-- - [ ] I have added tests that prove my fix is effective or that my feature works -->
  <!-- - [ ] New and existing unit tests pass locally with my changes -->
  <!-- - [ ] Any dependent changes have been merged and published in downstream modules -->
